### PR TITLE
fix: exported param types

### DIFF
--- a/src/base-get-media.ts
+++ b/src/base-get-media.ts
@@ -11,6 +11,9 @@ export type resizeToProps = {
 
 export interface BaseGetMediaProps {
   user_id: string;
+  /**
+   * Refer to https://developers.facebook.com/docs/instagram for more information on supported fields
+   */
   fields: string[]; // fields to include in response
   limit: number | string;
   access_token: string;

--- a/src/basic-display-api/get-media.ts
+++ b/src/basic-display-api/get-media.ts
@@ -1,7 +1,12 @@
 import { config } from '../config';
 import { BaseGetMediaProps, internalGetMediaForUser } from '../base-get-media';
-
+/**
+ * @deprecated
+ * Prefer using `GetMediaProps` instead
+ */
 export type getMediaProps = BaseGetMediaProps;
+
+export type GetMediaProps = BaseGetMediaProps;
 
 /**
  *
@@ -13,6 +18,6 @@ export type getMediaProps = BaseGetMediaProps;
  * This endpoint can only be used for reading user node that the token was generated for
  * To get media other users, please use `getMediaForUser` from `graph-api` module
  */
-export async function getMediaForUser(props: getMediaProps) {
+export async function getMediaForUser(props: GetMediaProps) {
   return internalGetMediaForUser(config.basicDisplayApiBaseUrl, { ...props });
 }

--- a/src/basic-display-api/refresh-token.ts
+++ b/src/basic-display-api/refresh-token.ts
@@ -7,7 +7,6 @@ export interface refreshTokenProps {
 
 /**
  * Refresh access long lived token
- * @requires permission: [instagram_graph_user_profile](https://developers.facebook.com/docs/instagram-basic-display-api/reference/refresh_access_token)
  */
 export async function refreshToken({ access_token }: refreshTokenProps) {
   const params = new URLSearchParams({});

--- a/src/graph-api/get-media.ts
+++ b/src/graph-api/get-media.ts
@@ -1,7 +1,13 @@
 import { BaseGetMediaProps, internalGetMediaForUser } from '../base-get-media';
 import { config } from '../config';
 
+/**
+ * @deprecated
+ * Prefer using `GetMediaProps` instead
+ */
 export type getMediaProps = BaseGetMediaProps;
+
+export type GetMediaProps = BaseGetMediaProps;
 
 /**
  *
@@ -11,6 +17,6 @@ export type getMediaProps = BaseGetMediaProps;
  * @requires permission: [pages_read_engagement](https://developers.facebook.com/docs/permissions/reference#reference-pages_read_engagement)
  * @see [Permissions](https://developers.facebook.com/docs/instagram-api/reference/media/)
  */
-export async function getMediaForUser(props: getMediaProps) {
+export async function getMediaForUser(props: GetMediaProps) {
   return internalGetMediaForUser(config.graphApiBaseUrl, { ...props });
 }


### PR DESCRIPTION
# Notes

## Changes
- New type GetMediaProps exported from both BasicDisplayApi and GraphApi modules

## Deprecated
- getMediaProps
  - use new GetMediaProps instead

closes #6